### PR TITLE
Rename @spencerlyon2 to @sglyon

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,4 +49,4 @@ about:
 extra:
   recipe-maintainers:
     - danielcsaba
-    - spencerlyon2
+    - sglyon


### PR DESCRIPTION
Appears @spencerlyon2 has changed his handle name to @sglyon. This PR makes that name change in the recipe so that this is transparent. If you could please confirm this is correct @danielcsaba and @sglyon, that would be greatly appreciated. Thanks.